### PR TITLE
Add loader test and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 1. [Read data from Google Sheets using Python](https://github.com/contactabhishekbasu/python_projects/blob/main/readgooglesheets.ipynb): Since reading data from Google Sheets is different from Excel or CSV file. In this tiny project, I will show you how to do it.
 
 2. [Predicting house prices based on other features](https://github.com/contactabhishekbasu/python_projects/blob/main/Predicting_house_prices_for_King_County_USA.ipynb): on the House Sales in King County, USA dataset
+
+## Running Tests
+
+Install dependencies and run pytest:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/google_sheet_loader.py
+++ b/google_sheet_loader.py
@@ -1,0 +1,28 @@
+import gspread
+import pandas as pd
+
+
+def load_google_sheet(spreadsheet_key: str, worksheet_name: str, credentials_path: str) -> pd.DataFrame:
+    """Load a Google Sheet worksheet into a DataFrame using gspread.
+
+    Parameters
+    ----------
+    spreadsheet_key : str
+        The unique key of the spreadsheet.
+    worksheet_name : str
+        Name of the worksheet within the spreadsheet.
+    credentials_path : str
+        Path to the service account credentials JSON file.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Data extracted from the worksheet with columns taken from the first row.
+    """
+    gc = gspread.service_account(filename=credentials_path)
+    sh = gc.open_by_key(spreadsheet_key)
+    worksheet = sh.worksheet(worksheet_name)
+    values = worksheet.get_all_values()
+    if not values:
+        return pd.DataFrame()
+    return pd.DataFrame(values[1:], columns=values[0])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+pytest
+gspread

--- a/tests/test_google_sheet.py
+++ b/tests/test_google_sheet.py
@@ -1,0 +1,28 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pandas as pd
+from unittest.mock import Mock, patch
+
+import google_sheet_loader
+
+
+def test_load_google_sheet_uses_first_row_as_columns():
+    data = [
+        ['col1', 'col2', 'col3'],
+        ['a', 'b', 'c'],
+        ['d', 'e', 'f']
+    ]
+    worksheet_mock = Mock()
+    worksheet_mock.get_all_values.return_value = data
+
+    sheet_mock = Mock()
+    sheet_mock.worksheet.return_value = worksheet_mock
+
+    gc_mock = Mock()
+    gc_mock.open_by_key.return_value = sheet_mock
+
+    with patch('google_sheet_loader.gspread.service_account', return_value=gc_mock):
+        df = google_sheet_loader.load_google_sheet('key', 'sheet1', 'creds.json')
+
+    assert list(df.columns) == data[0]
+    assert df.iloc[0].tolist() == data[1]


### PR DESCRIPTION
## Summary
- create `google_sheet_loader.py` with a helper to load a worksheet into a dataframe
- add `tests/test_google_sheet.py` mocking gspread
- document running pytest in README
- declare pytest and other dependencies in `requirements.txt`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756d578534833392219a29fe7ee9f3