### PR TITLE
Fix README URLs formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # python_projects
 
-1. [Read data from Google Sheets using Python](https://github.com/contactabhishekbasu/python_projects/blob/main/readgooglesheets.ipynb): Since reading data from Google Sheets is different from Excel or CSV file. In this tiny project, I will show you how to do it.
-
-2. [Predicting house prices based on other features](https://github.com/contactabhishekbasu/python_projects/blob/main/Predicting_house_prices_for_King_County_USA.ipynb): on the House Sales in King County, USA dataset
+1. [Read data from Google Sheets using Python](https://github.com/contactabhishekbasu/python_projects/blob/main/readgooglesheets.ipynb) - Since reading data from Google Sheets is different from Excel or CSV files, this tiny project shows how to do it.
+2. [Predicting house prices based on other features](https://github.com/contactabhishekbasu/python_projects/blob/main/Predicting_house_prices_for_King_County_USA.ipynb) - On the House Sales in King County, USA dataset.


### PR DESCRIPTION
## Summary
- remove line breaks around Markdown links in README
- keep URLs continuous and tweak bullet formatting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68756d4fc0608333bc4818b5ded20bf4